### PR TITLE
Add debug visualization for iterator

### DIFF
--- a/src/etc/natvis/intrinsic.natvis
+++ b/src/etc/natvis/intrinsic.natvis
@@ -145,4 +145,7 @@
       <Synthetic Name="[...]"><DisplayString>...</DisplayString></Synthetic>
     </Expand>
   </Type>
+  <Type Name="core::slice::Iter&lt;*&gt;">
+    <DisplayString>{*ptr.pointer}</DisplayString>
+  </Type>
 </AutoVisualizer>


### PR DESCRIPTION
Issue Details:
There isn't any natvis element to support the visualization of debug info for Rust iterators.

Fix Details:
Add custom display for iterators' content in intrinsic.natvis