### PR TITLE
Rewrite natvis description for HashMap to improve the visualization of key-value pairs in WinDbg

### DIFF
--- a/src/etc/natvis/libstd.natvis
+++ b/src/etc/natvis/libstd.natvis
@@ -41,7 +41,7 @@
           <If Condition="(base.table.ctrl.pointer[i] &amp; 0x80) == 0">
             <!-- Bucket is populated -->
             <Exec>n--</Exec>
-            <Item Name="{((tuple&lt;$T1, $T2&gt;*)base.table.ctrl.pointer)[-(i + 1)].__0}">((tuple&lt;$T1, $T2&gt;*)base.table.ctrl.pointer)[-(i + 1)].__1</Item>
+            <Item>((tuple&lt;$T1,$T2&gt;*)base.table.ctrl.pointer)[-(i + 1)]</Item>
           </If>
           <Exec>i++</Exec>
         </Loop>


### PR DESCRIPTION
The natvis description of Rust HashMap contains this line:
```
<Item Name="{((tuple&lt;$T1, $T2&gt;*)base.table.ctrl.pointer)[-(i + 1)].__0}">((tuple&lt;$T1, $T2&gt;*)base.table.ctrl.pointer)[-(i + 1)].__1</Item>
```
WinDbg's natvis executor fails to cast ```base.table.ctrl.pointer``` to ```tuple&lt;$T1, $T2&gt;*```, leading to this issue https://github.com/rust-lang/rust/issues/82674. The cause of this failure comes from WinDbg's syntax parser, which adds a whitespace between ```$T1``` and ```$T2``` after substituting them by the corresponding parametric types. While waiting for a fix from WinDbg side, I propose this work-around.

For this program:
```rust
use std::fmt;

#[derive(PartialEq, Eq, Hash)]
struct Student {
    name: String,
    country: String,
}

impl fmt::Display for Student {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        write!(f, "({}, {})", self.name, self.country)
    }
}

fn main() {
    use std::collections::HashMap;
    let mut map = HashMap::new();
    let s1 = Student { name: String::from("Nam"), country: String::from("UK") };
    let s2 = Student { name: String::from("Alex"), country: String::from("US")};
    map.insert(s1, 10);
    map.insert(s2, 8);
    for (k,v) in map.iter() {
        println!("{}, {}", k, v);
    }
}
```
Here is the HashMap visualization before the fix:
![image](https://user-images.githubusercontent.com/74681961/109541810-0fd23d00-7a79-11eb-836c-ad901d73aca9.png)

Here is the HashMap visualization after the fix:
![image](https://user-images.githubusercontent.com/74681961/109541766-03e67b00-7a79-11eb-8c12-009d2c1c26bb.png)
